### PR TITLE
Migrate to null safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.0
+
+- Migrate to Dart v2.12.0 null safety 
+
 ## 0.1.0
 
 - dart2

--- a/lib/mod97.dart
+++ b/lib/mod97.dart
@@ -15,8 +15,7 @@ library mod97;
 ///
 /// The [onError] function is only invoked if [source] is a [String]. It is
 /// not invoked if the [source] is, for example, `null`.
-
-int mod97(String source, {int onError(String source)}) {
+int mod97(String source, {int onError(String source)?}) {
   if (source.trim().startsWith('-')) {
     if (onError != null) {
       return onError(source);
@@ -28,8 +27,8 @@ int mod97(String source, {int onError(String source)}) {
 
   while (remainder.length > 2) {
     block = remainder.length < 9 ? remainder : remainder.substring(0, 9);
-    remainder = '${int.parse(block, onError: onError) % 97}${remainder.substring(block.length)}';
+    remainder = '${int.parse(block) % 97}${remainder.substring(block.length)}';
   }
 
-  return int.parse(remainder, onError: onError) % 97;
+  return int.parse(remainder) % 97;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: mod97
 description: Calculate the modulo 97.
-version: 0.1.0
+version: 1.0.0
 author: Christian Loitsch <christian@loitsch.com>
 homepage: https://github.com/close2/mod97
 
 environment:
-  sdk: '>=1.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dev_dependencies:
-  test: '>0.12.0 <2.0.0'
+  test: '>1.16.0 <2.0.0'


### PR DESCRIPTION
Hi @close2,

thanks for providing mod97 and iban. 
I followed the migration guide, bumped the major version and ran the tests.
One thing i had to change is:
Previously, onError was also passed to int#parse - now the onError parameter is deprecated and will be removed in future releases of dart. Therefore i omitted it and only used the provided onError argument in case the given string is negative (as the docs specify). Anyways i think previously it was already maybe not intended that onError was passed to int#parse as that is not documented in the dartdoc and also i think it is not expected in that case. We could reproduce the old behavior by using int#tryParse and checking whether it returns null but that seems unnecessary - if a non negative number is given initially, it should always work. And if the user provides some string but not a number, it's fine to throw the exception i guess.

Please let me know what you think about it. I could then follow up with the migration of iban.